### PR TITLE
Closes VL-15 added the possibility to set one of the defined Crs

### DIFF
--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/LeafletMap.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/LeafletMap.java
@@ -120,6 +120,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.vaadin.addons.componentfactory.leaflet.types.CustomSimpleCrs;
 
 @Tag("leaflet-map")
 @NpmPackage(value = "leaflet", version = "1.9.4")
@@ -142,11 +143,11 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
 
     private boolean ready = false;
 
-    private Class<? extends MapOptions> optionsClass;
+    private final Class<? extends MapOptions> optionsClass;
     
-    private List<LeafletEventType> events = new ArrayList<>(); 
+    private final List<LeafletEventType> events = new ArrayList<>();
     
-    private List<Class<? extends LeafletEvent>> eventsClasses = Arrays.asList(AddEvent.class,
+    private final List<Class<? extends LeafletEvent>> eventsClasses = Arrays.asList(AddEvent.class,
         BaseLayerChangeEvent.class, DragEndEvent.class, DragEvent.class, ErrorEvent.class,
         KeyDownEvent.class, KeyPressEvent.class, KeyUpEvent.class, LayerAddEvent.class,
         LayerRemoveEvent.class, LoadEvent.class, LocationEvent.class, MouseClickEvent.class,
@@ -169,12 +170,27 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
         getModel().setMapOptions(mapOptions);
         setSizeFull();
         registerListeners();
-    }  
+    }
+
+    public void setMapOptions(MapOptions mapOptions) {
+        getModel().setMapOptions(mapOptions);
+        invalidateSize();
+    }
+
+    /**
+     * Please, make sure to set the Crs before adding the Map to Vaadin Hierarchy.
+     * @param customSimpleCrs A new Crs
+     */
+    public void setCustomCrs(CustomSimpleCrs customSimpleCrs){
+        MapOptions mapOptions = getModel().getMapOptions();
+        mapOptions.setCustomSimpleCrs(customSimpleCrs);
+        setMapOptions(mapOptions);
+    }
     
     private LeafletModel getModel() {
         return new LeafletModel() {
 
-            ObjectMapper objectMapper = new ObjectMapper();            
+            final ObjectMapper objectMapper = new ObjectMapper();
                         
             @Override
             public MapOptions getMapOptions() {
@@ -229,9 +245,9 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
     /**
      * Fires the given leaflet event
      * 
-     * @param layerId
+     * @param layer
      *            the layer where the event occurred
-     * @param eventType
+     * @param event
      *            the event object to be propagate
      * @see LeafletEvent
      */

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/map/options/DefaultMapOptions.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/map/options/DefaultMapOptions.java
@@ -15,17 +15,19 @@
 package org.vaadin.addons.componentfactory.leaflet.layer.map.options;
 
 import java.util.UUID;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.vaadin.addons.componentfactory.leaflet.types.CustomSimpleCrs;
 import org.vaadin.addons.componentfactory.leaflet.types.LatLng;
 import org.vaadin.addons.componentfactory.leaflet.types.LatLngBounds;
 
 /**
  * Map options with leaflet default values
- * 
  * @author <strong>Gabor Kokeny</strong> Email:
- *         <a href='mailto=kokeny19@gmail.com'>kokeny19@gmail.com</a>
- * 
- * @since 2020-03-06
+ * <a href='mailto=kokeny19@gmail.com'>kokeny19@gmail.com</a>
  * @version 1.0
+ * @since 2020-03-06
  */
 public class DefaultMapOptions implements MapOptions {
 
@@ -56,6 +58,23 @@ public class DefaultMapOptions implements MapOptions {
     private Integer maxZoom = 20;
     private LatLngBounds maxBounds;
     private LatLngBounds bounds;
+    @Getter
+    private String crsName;
+
+    @Getter
+    private CustomSimpleCrs customSimpleCrs;
+
+    @Override
+    public void setCrsName(String crsName) {
+        this.crsName = crsName;
+        this.customSimpleCrs = null;
+    }
+
+    @Override
+    public void setCustomSimpleCrs(CustomSimpleCrs customSimpleCrs) {
+        this.customSimpleCrs = customSimpleCrs;
+        this.crsName = null;
+    }
 
     // Animation Options
     private boolean zoomAnimation = true;

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/map/options/MapStateOptions.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/map/options/MapStateOptions.java
@@ -15,17 +15,17 @@
 package org.vaadin.addons.componentfactory.leaflet.layer.map.options;
 
 import java.io.Serializable;
+
+import org.vaadin.addons.componentfactory.leaflet.types.CustomSimpleCrs;
 import org.vaadin.addons.componentfactory.leaflet.types.LatLng;
 import org.vaadin.addons.componentfactory.leaflet.types.LatLngBounds;
 
 /**
  * Leaflet map state options
- * 
  * @author <strong>Gabor Kokeny</strong> Email:
- *         <a href='mailto=kokeny19@gmail.com'>kokeny19@gmail.com</a>
- * 
- * @since 2020-03-06
+ * <a href='mailto=kokeny19@gmail.com'>kokeny19@gmail.com</a>
  * @version 1.0
+ * @since 2020-03-06
  */
 public interface MapStateOptions extends Serializable {
 
@@ -33,7 +33,6 @@ public interface MapStateOptions extends Serializable {
 
     /**
      * Initial geographic center of the map
-     * 
      * @param center the intial center of the map
      */
     void setCenter(LatLng center);
@@ -42,7 +41,6 @@ public interface MapStateOptions extends Serializable {
 
     /**
      * Initial map zoom level
-     * 
      * @param zoom the initial map zoom level
      */
     void setZoom(Integer zoom);
@@ -50,14 +48,12 @@ public interface MapStateOptions extends Serializable {
     /**
      * Sets a map view that contains the given geographical bounds with the maximum
      * zoom level possible.
-     * 
      * @param bounds the geographical bounds of the map
      */
     void setBounds(LatLngBounds bounds);
 
     /**
      * Returns the geographical bounds visible in the current map view
-     * 
      * @return the geographical bounds of the map
      */
     LatLngBounds getBounds();
@@ -68,7 +64,6 @@ public interface MapStateOptions extends Serializable {
      * Minimum zoom level of the map. If not specified and at least one GridLayer or
      * TileLayer is in the map, the lowest of their minZoom options will be used
      * instead.
-     * 
      * @param minZoom the minimum zoom level of the map
      */
     void setMinZoom(Integer minZoom);
@@ -79,7 +74,6 @@ public interface MapStateOptions extends Serializable {
      * Maximum zoom level of the map. If not specified and at least one GridLayer or
      * TileLayer is in the map, the highest of their maxZoom options will be used
      * instead.
-     * 
      * @param maxZoom the maximum zoom level of the map
      */
     void setMaxZoom(Integer maxZoom);
@@ -90,8 +84,34 @@ public interface MapStateOptions extends Serializable {
      * When this option is set, the map restricts the view to the given geographical
      * bounds, bouncing the user back if the user tries to pan outside the view. To
      * set the restriction dynamically, use setMaxBounds method.
-     * 
      * @param maxBounds restricts the view to the given bounds
      */
     void setMaxBounds(LatLngBounds maxBounds);
+
+    String getCrsName();
+
+    /**
+     * Should be one of the known CRS.
+     * Default ones are
+     * <ul>
+     *     <li>L.CRS.EPSG3395</li>
+     *     <li>L.CRS.EPSG4326</li>
+     *     <li>L.CRS.Simple</li>
+     * </ul>
+     * @param crsName a String
+     * @see CustomSimpleCrs.BaseCrs#toLeaflet()
+     */
+    void setCrsName(String crsName);
+
+    /**
+     * To set the Crs to one of the defined ones (see <a href="https://leafletjs.com/reference.html#crs">CRS in
+     * Leaflet</a>)
+     */
+    default void setSupportedCrs(CustomSimpleCrs.BaseCrs supportedCrs) {
+        setCrsName(supportedCrs.toLeaflet());
+    }
+
+    void setCustomSimpleCrs(CustomSimpleCrs customSimpleCrs);
+
+    CustomSimpleCrs getCustomSimpleCrs();
 }

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/types/CustomSimpleCrs.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/types/CustomSimpleCrs.java
@@ -1,0 +1,66 @@
+package org.vaadin.addons.componentfactory.leaflet.types;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+/**
+ * Crs parameters that models a Leaflet CRS that extends Crs.Simple: it uses a plat-carré projection with the
+ * extents given by the min_* and max_* parameters. For the meaning of the
+ * affine transform parameters, see: http://leafletjs.com/reference.html#transformation.
+ */
+public class CustomSimpleCrs implements Serializable {
+
+    public enum BaseCrs {
+        L_CRS_EPSG3395, // https://epsg.io/3395 WGS 84 / World Mercator
+        L_CRS_EPSG4326, // https://epsg.io/4326 WGS84 in degree, WGS 84 - WGS84 - World Geodetic System 1984, used in GPS
+        L_CRS_Simple;
+
+        public String toLeaflet() {
+            return name().replaceAll("_", ".")
+                    .replaceAll("L.CRS.", "");
+        }
+    }
+
+    // Name for the new Crs.
+    private String name;
+    // the min_x value
+    private double min_x;
+    // the min_y value
+    private double min_y;
+    // the max_x value
+    private double max_x;
+    // the max_y value
+    private double max_y;
+    // a in transformation calculation (a*x + b, c*y + d)
+    private double a;
+    // b in transformation calculation (a*x + b, c*y + d)
+    private double b;
+    // c in transformation calculation (a*x + b, c*y + d)
+    private double c;
+    // d in transformation calculation (a*x + b, c*y + d)
+    private double d;
+
+    public CustomSimpleCrs(String name, double min_x, double min_y, double max_x, double max_y, double a, double b, double c, double d) {
+        this.name = name;
+
+        this.min_x = min_x;
+        this.min_y = min_y;
+        this.max_x = max_x;
+        this.max_y = max_y;
+
+        this.a = a;
+        this.b = b;
+        this.c = c;
+        this.d = d;
+    }
+
+    public CustomSimpleCrs(String name, Point minPoint, Point maxPoint, double a, double b, double c, double d) {
+        this(name, minPoint.getX(), minPoint.getY(), maxPoint.getX(), maxPoint.getY(), a, b, c, d);
+    }
+}

--- a/src/main/resources/META-INF/resources/frontend/leaflet-map.js
+++ b/src/main/resources/META-INF/resources/frontend/leaflet-map.js
@@ -17,17 +17,17 @@
  * limitations under the License.
  * #L%
  */
- 
+
 /* 
  * This file incorporates work licensed under the Apache License, Version 2.0
  * Copyright 2020 Gabor Kokeny and contributors
  */
 
-import { html, PolymerElement } from "@polymer/polymer/polymer-element.js";
-import { ThemableMixin } from "@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js";
+import {html, PolymerElement} from "@polymer/polymer/polymer-element.js";
+import {ThemableMixin} from "@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js";
 import * as L from "leaflet/dist/leaflet-src.js";
 
-import { LeafletTypeConverter } from "./leaflet-type-converter.js";
+import {LeafletTypeConverter} from "./leaflet-type-converter.js";
 
 class LeafletMap extends ThemableMixin(PolymerElement) {
   static get template() {
@@ -76,10 +76,10 @@ class LeafletMap extends ThemableMixin(PolymerElement) {
 
     this.leafletConverter = new LeafletTypeConverter(L);
     // console.log("LeafletMap - ready() using converter", this.leafletConverter);
-
     // init leaflet map
-    let map = this.toLeafletMap(JSON.parse(this.mapOptions));
-    this.map = map;
+    let options = JSON.parse(this.mapOptions)
+    options = this.leafletConverter.tryToSetCrs(options)
+    this.map = this.toLeafletMap(options);
   }
 
   /**
@@ -181,6 +181,7 @@ class LeafletMap extends ThemableMixin(PolymerElement) {
     // console.log("LeafletMap - initialize map with options: {}", options);
     let mapElement = this.shadowRoot.getElementById("map");
     // console.log("LeafletMap - using DOM element: {}", mapElement);
+    console.log("With Options" + options)
     let leafletMap = L.map(mapElement, options);
     leafletMap._controls = [];
     this.events

--- a/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/LeafletDemoApp.java
+++ b/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/LeafletDemoApp.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,8 +17,8 @@
  * limitations under the License.
  * #L%
  */
- 
-/* 
+
+/*
  * This file incorporates work licensed under the Apache License, Version 2.0
  * Copyright 2020 Gabor Kokeny and contributors
  */
@@ -42,16 +42,7 @@ import org.vaadin.addons.componentfactory.leaflet.demo.view.controls.LayersContr
 import org.vaadin.addons.componentfactory.leaflet.demo.view.controls.RemoveDefaultControlsExample;
 import org.vaadin.addons.componentfactory.leaflet.demo.view.controls.ScaleControlExample;
 import org.vaadin.addons.componentfactory.leaflet.demo.view.layers.MultipleBaseLayersExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.map.MapConversionMethodsExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.map.MapDarkThemeExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.map.MapDialogExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.map.MapEventsExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.map.MapFunctionsExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.map.MapGeolocationExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.map.MapMaxBoundsExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.map.MapPollListenerExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.map.MapStateFuncionsExmple;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.map.MultipleMapsExample;
+import org.vaadin.addons.componentfactory.leaflet.demo.view.map.*;
 import org.vaadin.addons.componentfactory.leaflet.demo.view.marker.DivOverlayStyleExample;
 import org.vaadin.addons.componentfactory.leaflet.demo.view.marker.MarkerDivIconExample;
 import org.vaadin.addons.componentfactory.leaflet.demo.view.marker.MarkerMethodCallExample;
@@ -79,90 +70,91 @@ import org.vaadin.addons.componentfactory.leaflet.demo.view.plugins.VectorBasema
 @CssImport(value = "styles/demo-applayout.css", themeFor = "vaadin-app-layout")
 public class LeafletDemoApp extends AppLayout implements AfterNavigationObserver {
 
-	private static final long serialVersionUID = -9119767347112138141L;
+    private static final long serialVersionUID = -9119767347112138141L;
 
-	private AppMenu appMenu = AppMenu.create();
-	
-	public LeafletDemoApp() {
-		DrawerToggle drawerToggle = new DrawerToggle();
-		drawerToggle.setIcon(new Icon(VaadinIcon.MENU));
-		addToNavbar(true, drawerToggle);
+    private AppMenu appMenu = AppMenu.create();
 
-		// Leaflet Icon
-		Image image = new Image("https://leafletjs.com/docs/images/logo.png", "icon");
-		image.setHeight("30px");
-		image.getStyle().set("margin", "10px");
-		image.addClickListener((e) -> UI.getCurrent().getPage().setLocation("https://leafletjs.com/"));
-		addToNavbar(image);
+    public LeafletDemoApp() {
+        DrawerToggle drawerToggle = new DrawerToggle();
+        drawerToggle.setIcon(new Icon(VaadinIcon.MENU));
+        addToNavbar(true, drawerToggle);
 
-		// App title
-		Label appTitle = new Label("Vaadin - Leaflet examples");
-		appTitle.setWidthFull();
-		appTitle.getStyle().set("font-size", "20px");
-		appTitle.getStyle().set("margin-left", "10px");
-		appTitle.getStyle().set("font-weight", "300");
-		addToNavbar(appTitle);
+        // Leaflet Icon
+        Image image = new Image("https://leafletjs.com/docs/images/logo.png", "icon");
+        image.setHeight("30px");
+        image.getStyle().set("margin", "10px");
+        image.addClickListener((e) -> UI.getCurrent().getPage().setLocation("https://leafletjs.com/"));
+        addToNavbar(image);
 
-		// Application menubar
-		initializeDemoMenu();
-	}
+        // App title
+        Label appTitle = new Label("Vaadin - Leaflet examples");
+        appTitle.setWidthFull();
+        appTitle.getStyle().set("font-size", "20px");
+        appTitle.getStyle().set("margin-left", "10px");
+        appTitle.getStyle().set("font-weight", "300");
+        addToNavbar(appTitle);
 
-	private void initializeDemoMenu() {
+        // Application menubar
+        initializeDemoMenu();
+    }
 
-		// Map examples
-		AppMenuItem.create("Map", new Icon(VaadinIcon.GLOBE)).addSubMenu(MapEventsExample.class)
-				.addSubMenu(MapMaxBoundsExample.class).addSubMenu(MapDarkThemeExample.class)
-				.addSubMenu(MapPollListenerExample.class).addSubMenu(MapGeolocationExample.class)
-				.addSubMenu(MapFunctionsExample.class).addSubMenu(MapConversionMethodsExample.class)
-				.addSubMenu(MapDialogExample.class)
-				.addSubMenu(MultipleMapsExample.class)
-        .addSubMenu(MapStateFuncionsExmple.class)
-				.addTo(appMenu);
+    private void initializeDemoMenu() {
 
-		// Marker examples
-		AppMenuItem.create("Markers", new Icon(VaadinIcon.MAP_MARKER)).addSubMenu(MarkersSimpleExample.class)
-				.addSubMenu(MarkersEventsExample.class).addSubMenu(MarkersWithEventsExample.class)
-				.addSubMenu(MarkersGroupExample.class).addSubMenu(MarkersAddAndRemoveExample.class)
-				.addSubMenu(MarkersChangingIconExample.class).addSubMenu(MarkersRemoveOnClickExample.class)
-				.addSubMenu(MarkerMethodCallExample.class)
-				.addSubMenu(MarkerDivIconExample.class)
-				.addSubMenu(DivOverlayStyleExample.class)
-				.addTo(appMenu);
+        // Map examples
+        AppMenuItem.create("Map", new Icon(VaadinIcon.GLOBE)).addSubMenu(MapEventsExample.class)
+                .addSubMenu(MapMaxBoundsExample.class).addSubMenu(MapDarkThemeExample.class)
+                .addSubMenu(MapPollListenerExample.class).addSubMenu(MapGeolocationExample.class)
+                .addSubMenu(MapFunctionsExample.class).addSubMenu(MapConversionMethodsExample.class)
+                .addSubMenu(MapDialogExample.class)
+                .addSubMenu(MultipleMapsExample.class)
+                .addSubMenu(MapStateFuncionsExmple.class)
+                .addSubMenu(MapCrsExample.class)
+                .addTo(appMenu);
 
-		// Layers examples
-		AppMenuItem.create("Layers", new Icon(VaadinIcon.GRID_SMALL))
-				.addSubMenu(MultipleBaseLayersExample.class);
+        // Marker examples
+        AppMenuItem.create("Markers", new Icon(VaadinIcon.MAP_MARKER)).addSubMenu(MarkersSimpleExample.class)
+                .addSubMenu(MarkersEventsExample.class).addSubMenu(MarkersWithEventsExample.class)
+                .addSubMenu(MarkersGroupExample.class).addSubMenu(MarkersAddAndRemoveExample.class)
+                .addSubMenu(MarkersChangingIconExample.class).addSubMenu(MarkersRemoveOnClickExample.class)
+                .addSubMenu(MarkerMethodCallExample.class)
+                .addSubMenu(MarkerDivIconExample.class)
+                .addSubMenu(DivOverlayStyleExample.class)
+                .addTo(appMenu);
 
-		// Paths examples
-		AppMenuItem.create("Paths", new Icon(VaadinIcon.FILL)).addSubMenu(PathSimpleExample.class)
-				.addSubMenu(TypeOfPathsExample.class).addSubMenu(PathsEventPropagationExample.class)
-				.addSubMenu(FlyToPolygonBoundsExample.class).addSubMenu(Paths3000Example.class)
-				.addSubMenu(PathsStyleExample.class).addTo(appMenu);
+        // Layers examples
+        AppMenuItem.create("Layers", new Icon(VaadinIcon.GRID_SMALL))
+                .addSubMenu(MultipleBaseLayersExample.class);
 
-		// Controls examples
-		AppMenuItem.create("Controls", new Icon(VaadinIcon.ARROWS))
-				.addSubMenu(RemoveDefaultControlsExample.class)
-				.addSubMenu(LayersControlExample.class)
-				.addSubMenu(ControlPositionExample.class)
-				.addSubMenu(ScaleControlExample.class).addTo(appMenu);
+        // Paths examples
+        AppMenuItem.create("Paths", new Icon(VaadinIcon.FILL)).addSubMenu(PathSimpleExample.class)
+                .addSubMenu(TypeOfPathsExample.class).addSubMenu(PathsEventPropagationExample.class)
+                .addSubMenu(FlyToPolygonBoundsExample.class).addSubMenu(Paths3000Example.class)
+                .addSubMenu(PathsStyleExample.class).addTo(appMenu);
 
-		// Mixins examples
+        // Controls examples
+        AppMenuItem.create("Controls", new Icon(VaadinIcon.ARROWS))
+                .addSubMenu(RemoveDefaultControlsExample.class)
+                .addSubMenu(LayersControlExample.class)
+                .addSubMenu(ControlPositionExample.class)
+                .addSubMenu(ScaleControlExample.class).addTo(appMenu);
 
-		// Plugins examples
-		AppMenuItem.create("Plugins", new Icon(VaadinIcon.PLUG)).addSubMenu(FullScreenPluginExample.class)
-        .addSubMenu(HeatmapPluginExample.class)
-        .addSubMenu(MarkerClusterPluginExample.class)
-        .addSubMenu(KmzLayerPluginExample.class)
-        .addSubMenu(DynamicMapLayerPluginExample.class)
-        .addSubMenu(TiledMapLayerPluginExample.class)
-        .addSubMenu(VectorBasemapLayerPluginExample.class)
-        .addTo(appMenu);
+        // Mixins examples
 
-		addToDrawer(appMenu);
-	}
+        // Plugins examples
+        AppMenuItem.create("Plugins", new Icon(VaadinIcon.PLUG)).addSubMenu(FullScreenPluginExample.class)
+                .addSubMenu(HeatmapPluginExample.class)
+                .addSubMenu(MarkerClusterPluginExample.class)
+                .addSubMenu(KmzLayerPluginExample.class)
+                .addSubMenu(DynamicMapLayerPluginExample.class)
+                .addSubMenu(TiledMapLayerPluginExample.class)
+                .addSubMenu(VectorBasemapLayerPluginExample.class)
+                .addTo(appMenu);
 
-	@Override
-	public void afterNavigation(AfterNavigationEvent event) {
-		appMenu.setActivePath(event.getLocation().getPath());
-	}
+        addToDrawer(appMenu);
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        appMenu.setActivePath(event.getLocation().getPath());
+    }
 }

--- a/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/map/MapCrsExample.java
+++ b/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/map/MapCrsExample.java
@@ -1,0 +1,130 @@
+package org.vaadin.addons.componentfactory.leaflet.demo.view.map;
+
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import org.jetbrains.annotations.NotNull;
+import org.vaadin.addons.componentfactory.leaflet.LeafletMap;
+import org.vaadin.addons.componentfactory.leaflet.controls.LayersControl;
+import org.vaadin.addons.componentfactory.leaflet.controls.ScaleControl;
+import org.vaadin.addons.componentfactory.leaflet.demo.LeafletDemoApp;
+import org.vaadin.addons.componentfactory.leaflet.demo.components.ExampleContainer;
+import org.vaadin.addons.componentfactory.leaflet.layer.map.options.DefaultMapOptions;
+import org.vaadin.addons.componentfactory.leaflet.layer.map.options.MapOptions;
+import org.vaadin.addons.componentfactory.leaflet.layer.raster.TileLayer;
+import org.vaadin.addons.componentfactory.leaflet.plugins.mouseposition.MousePosition;
+import org.vaadin.addons.componentfactory.leaflet.types.CustomSimpleCrs;
+import org.vaadin.addons.componentfactory.leaflet.types.LatLng;
+import org.vaadin.addons.componentfactory.leaflet.types.LatLngBounds;
+import org.vaadin.addons.componentfactory.leaflet.types.Point;
+
+@PageTitle("Map CRS set method")
+@Route(value = "map/crs", layout = LeafletDemoApp.class)
+public class MapCrsExample extends ExampleContainer {
+    public static final String pidDescription = "LFI PLANIMETRIA GENERALE_05PB";
+    public static final String pidName = "6692552428045889120";
+    public static final double MIN_X = 309.318027212648;
+    public static final double MIN_Y = 352.775475776667;
+    public static final double WIDTH = 1398.35408166923;
+    public static final double HEIGHT = 841.052374599691;
+    public static final double[] crs = {0.000715126456960237, -0.221201504874512, -0.000715126456960237, 1.05300847847737};
+    public static final int MAX_ZOOM = 5;
+
+    @Override
+    protected void initDemo() {
+        CustomSimpleCrs customSimpleCrs = getCustomCrs();
+
+        MapOptions options = new DefaultMapOptions();
+        options.setSupportedCrs(CustomSimpleCrs.BaseCrs.L_CRS_Simple);
+        options.setCustomSimpleCrs(customSimpleCrs);
+
+        LeafletMap leafletMap = new LeafletMap(options);
+        new MousePosition().addTo(leafletMap);
+        new ScaleControl().addTo(leafletMap);
+        LayersControl layersControl = new LayersControl();
+        layersControl.addTo(leafletMap);
+
+        TileLayer layer = new TileLayer("https://tiles.anteash.com/tile/" + pidName + "/lod_{z}/layer_{x}_{y}.png");
+        layer.setNoWrap(true);
+        layer.addTo(leafletMap);
+        layersControl.addBaseLayer(layer, pidDescription);
+
+        // let's try to reset the options <em>after</em> the map was created, but before it is drawn
+        leafletMap.setMapOptions(options);
+        leafletMap.setMaxBounds(new LatLngBounds(new LatLng(MIN_Y, MIN_X), new LatLng(MIN_Y + HEIGHT, MIN_X + WIDTH)));
+        leafletMap.setMinZoom(0);
+        leafletMap.setMaxZoom(MAX_ZOOM);
+        leafletMap.setView(new LatLng(MIN_Y + HEIGHT / 2D, MIN_X + WIDTH / 2D), 0);
+        addToContent(leafletMap);
+    }
+
+    @NotNull
+    private CustomSimpleCrs getCustomCrs() {
+        Point point = new Point(MIN_X, MIN_Y);
+        Point point2 = new Point(point.getX() + WIDTH, point.getY() + HEIGHT);
+
+        return new CustomSimpleCrs("officeCrs", point, point2, crs[0], crs[1], crs[2], crs[3]);
+    }
+
+    /**
+     *
+     * Map:
+     * {
+     *   "name": "6692552428045889120",
+     *   "extension": "dwg",
+     *   "description": "LFI PLANIMETRIA GENERALE_05PB",
+     *   "nums_lods": 6,
+     *   "native_bbox": {
+     *     "x": 309.318027212648,
+     *     "y": 352.775475776667,
+     *     "w": 1398.35408166923,
+     *     "h": 841.052374599691
+     *   },
+     *   "degrees_bbox": {
+     *     "x": -149.5,
+     *     "y": -90,
+     *     "w": 299,
+     *     "h": 180
+     *   },
+     *   "resolutions": [1.16796875, 0.583984375, 0.2919921875, 0.14599609375, 0.072998046875, 0.0364990234375],
+     *   "crs": [0.000715126456960237, -0.221201504874512, -0.000715126456960237, 1.05300847847737],
+     *   "pixels": {
+     *     "x": 8192,
+     *     "y": 4940
+     *   },
+     *   "version": "17",
+     *   "root": "DEMO",
+     *   "path": "LFI PLANIMETRIA GENERALE_05PB",
+     *   "has_pdf": false
+     * }
+     *
+     * PID
+     * {
+     *   "name": "4934540697340134666",
+     *   "extension": "dwg",
+     *   "description": "DN813-405",
+     *   "nums_lods": 6,
+     *   "native_bbox": {
+     *     "x": -0.0367730818061318,
+     *     "y": -0.0255275322654143,
+     *     "w": 1205.14583397223,
+     *     "h": 836.601058960043
+     *   },
+     *   "degrees_bbox": {
+     *     "x": -129.5,
+     *     "y": -90,
+     *     "w": 259,
+     *     "h": 180
+     *   },
+     *   "resolutions": [1.01171875, 0.505859375, 0.2529296875, 0.12646484375, 0.063232421875, 0.0316162109375],
+     *   "crs": [0.000829775095935026, 0.000030513387483509, -0.000829775095935026, 0.847074179868423],
+     *   "pixels": {
+     *     "x": 8192,
+     *     "y": 5704
+     *   },
+     *   "version": "17",
+     *   "root": "DEMO",
+     *   "path": "DN813-405",
+     *   "has_pdf": false
+     * }
+     */
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,14 +4,14 @@
 // You might want to change the configurations to fit your preferences
 // For more information about the configurations, please refer to http://www.typescriptlang.org/docs/handbook/tsconfig-json.html
 {
-  "_version": "9.1",
+  "flow_version": "23.3.4",
   "compilerOptions": {
     "sourceMap": true,
     "jsx": "react-jsx",
     "inlineSources": true,
     "module": "esNext",
     "target": "es2020",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "strict": true,
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
and  Added the possibility to set a custom CRS:

- Created a CustomSimpleCrs java POJO to store information about CRS
- Expanded MapStateOptions with the possibilities to pass either an existing CRS name or a CustomeSimpleCrs to create a Javascript CRS object
- in leaflet-map.js we invoke methods of leaflet-type-converter to set CRS
- leaflet-type-converter.js we use the serialized CustomeSimpleCrs information to create a CRS object invoking the correct Leaflet methods.

Updated Confluence page for Vaadin Flow Leaflet addon and Geodesy