### PR TITLE
Closes VL-14 MousePosition can set options

### DIFF
--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/mouseposition/MousePosition.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/mouseposition/MousePosition.java
@@ -5,6 +5,7 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import lombok.Getter;
 import lombok.Setter;
+import org.vaadin.addons.componentfactory.leaflet.annotations.LeafletArgument;
 import org.vaadin.addons.componentfactory.leaflet.controls.LeafletControl;
 
 /**
@@ -27,22 +28,15 @@ import org.vaadin.addons.componentfactory.leaflet.controls.LeafletControl;
 public class MousePosition extends LeafletControl {
     private static final String JAVASCRIPT_CLASS_NAME = "mousePosition";
 
-    // To separate longitude\latitude values. Defaults to ' : '
-    private String separator = ":";
+    @LeafletArgument
+    private MousePositionOptions options;
 
-    // Initial text to display. Defaults to 'Unavailable'
-    private String emptystring = "Unavailable";
-
-    //Number of digits. Defaults to 5
-    private int numDigits = 5;
-
-    // Weather to put the longitude first or not. Defaults to false
-    private Boolean lngFirst = false;
-
-    //A string to be prepended to the coordinates. Defaults to the empty string ‘’.
-    private String prefix = "";
+    public MousePosition(MousePositionOptions options) {
+        super(JAVASCRIPT_CLASS_NAME);
+        this.options = options;
+    }
 
     public MousePosition() {
-        super(JAVASCRIPT_CLASS_NAME);
+        this(new MousePositionOptions());
     }
 }

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/mouseposition/MousePositionOptions.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/mouseposition/MousePositionOptions.java
@@ -1,0 +1,27 @@
+package org.vaadin.addons.componentfactory.leaflet.plugins.mouseposition;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MousePositionOptions implements Serializable {
+    //A string to be prepended to the coordinates. Defaults to the empty string ‘’.
+    private String prefix = "";
+
+    // To separate longitude\latitude values. Defaults to ' : '
+    private String separator = " : ";
+
+    // Initial text to display. Defaults to 'Unavailable'
+    private String emptystring = "Unavailable";
+
+    //Number of digits. Defaults to 5
+    private int numDigits = 5;
+
+    // Weather to put the longitude first or not. Defaults to false
+    private Boolean lngFirst = false;
+}

--- a/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/map/MapCrsExample.java
+++ b/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/map/MapCrsExample.java
@@ -12,6 +12,7 @@ import org.vaadin.addons.componentfactory.leaflet.layer.map.options.DefaultMapOp
 import org.vaadin.addons.componentfactory.leaflet.layer.map.options.MapOptions;
 import org.vaadin.addons.componentfactory.leaflet.layer.raster.TileLayer;
 import org.vaadin.addons.componentfactory.leaflet.plugins.mouseposition.MousePosition;
+import org.vaadin.addons.componentfactory.leaflet.plugins.mouseposition.MousePositionOptions;
 import org.vaadin.addons.componentfactory.leaflet.types.CustomSimpleCrs;
 import org.vaadin.addons.componentfactory.leaflet.types.LatLng;
 import org.vaadin.addons.componentfactory.leaflet.types.LatLngBounds;
@@ -38,7 +39,11 @@ public class MapCrsExample extends ExampleContainer {
         options.setCustomSimpleCrs(customSimpleCrs);
 
         LeafletMap leafletMap = new LeafletMap(options);
-        new MousePosition().addTo(leafletMap);
+
+        MousePositionOptions mousePositionOptions = new MousePositionOptions();
+        mousePositionOptions.setPrefix("Lat ");
+        mousePositionOptions.setSeparator(" : Lon ");
+        new MousePosition(mousePositionOptions).addTo(leafletMap);
         new ScaleControl().addTo(leafletMap);
         LayersControl layersControl = new LayersControl();
         layersControl.addTo(leafletMap);


### PR DESCRIPTION
Now the options are correctly serialized and used to initialize the Leaflet control MousePosition:

- Created a new class MousePositionOptions that is serializable so it can be sent to the client
- Added a field in MousePosition class and annotated with @LeafletArgument so that the Javascript object is automatically instantiate with it in the constructor
- An example of usage is inside MapCrsExample