### PR TITLE
Closes VL-17 events: removing only a listener and adding one later

### DIFF
--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/LeafletMap.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/LeafletMap.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@
  * #L%
  */
 
-/* 
+/*
  * This file incorporates work licensed under the Apache License, Version 2.0
  * Copyright 2020 Gabor Kokeny and contributors
  */
@@ -110,14 +110,17 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.JsonType;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.vaadin.addons.componentfactory.leaflet.types.CustomSimpleCrs;
@@ -144,21 +147,21 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
     private boolean ready = false;
 
     private final Class<? extends MapOptions> optionsClass;
-    
+
     private final List<LeafletEventType> events = new ArrayList<>();
-    
+
     private final List<Class<? extends LeafletEvent>> eventsClasses = Arrays.asList(AddEvent.class,
-        BaseLayerChangeEvent.class, DragEndEvent.class, DragEvent.class, ErrorEvent.class,
-        KeyDownEvent.class, KeyPressEvent.class, KeyUpEvent.class, LayerAddEvent.class,
-        LayerRemoveEvent.class, LoadEvent.class, LocationEvent.class, MouseClickEvent.class,
-        MouseContextMenuEvent.class, MouseDoubleClickEvent.class, MouseDownEvent.class,
-        MouseMoveEvent.class, MouseOutEvent.class, MouseOverEvent.class, MousePreClickEvent.class,
-        MouseUpEvent.class, MoveEndEvent.class, MoveStartEvent.class, OverlayAddEvent.class,
-        OverlayRemoveEvent.class, PopupCloseEvent.class, PopupOpenEvent.class, RemoveEvent.class,
-        ResizeEvent.class, TileErrorEvent.class, TileLoadEvent.class, TileUnloadEvent.class,
-        TileLoadStartEvent.class, TooltipCloseEvent.class, TooltipOpenEvent.class,
-        UnloadEvent.class, ViewResetEvent.class, ZoomAnimEvent.class, ZoomEndEvent.class,
-        ZoomEvent.class, ZoomLevelsChangeEvent.class, ZoomStartEvent.class);
+            BaseLayerChangeEvent.class, DragEndEvent.class, DragEvent.class, ErrorEvent.class,
+            KeyDownEvent.class, KeyPressEvent.class, KeyUpEvent.class, LayerAddEvent.class,
+            LayerRemoveEvent.class, LoadEvent.class, LocationEvent.class, MouseClickEvent.class,
+            MouseContextMenuEvent.class, MouseDoubleClickEvent.class, MouseDownEvent.class,
+            MouseMoveEvent.class, MouseOutEvent.class, MouseOverEvent.class, MousePreClickEvent.class,
+            MouseUpEvent.class, MoveEndEvent.class, MoveStartEvent.class, OverlayAddEvent.class,
+            OverlayRemoveEvent.class, PopupCloseEvent.class, PopupOpenEvent.class, RemoveEvent.class,
+            ResizeEvent.class, TileErrorEvent.class, TileLoadEvent.class, TileUnloadEvent.class,
+            TileLoadStartEvent.class, TooltipCloseEvent.class, TooltipOpenEvent.class,
+            UnloadEvent.class, ViewResetEvent.class, ZoomAnimEvent.class, ZoomEndEvent.class,
+            ZoomEvent.class, ZoomLevelsChangeEvent.class, ZoomStartEvent.class);
 
     public LeafletMap() {
         this(new DefaultMapOptions());
@@ -181,17 +184,17 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
      * Please, make sure to set the Crs before adding the Map to Vaadin Hierarchy.
      * @param customSimpleCrs A new Crs
      */
-    public void setCustomCrs(CustomSimpleCrs customSimpleCrs){
+    public void setCustomCrs(CustomSimpleCrs customSimpleCrs) {
         MapOptions mapOptions = getModel().getMapOptions();
         mapOptions.setCustomSimpleCrs(customSimpleCrs);
         setMapOptions(mapOptions);
     }
-    
+
     private LeafletModel getModel() {
         return new LeafletModel() {
 
             final ObjectMapper objectMapper = new ObjectMapper();
-                        
+
             @Override
             public MapOptions getMapOptions() {
                 try {
@@ -206,49 +209,46 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
 
             @Override
             public void setMapOptions(MapOptions mapOptions) {
-                try {                    
+                try {
                     getElement().setProperty("mapOptions", objectMapper.writeValueAsString(mapOptions));
                 } catch (JsonProcessingException e) {
                     logger.error("Error serializing map options", e);
                 }
             }
-            
+
             @Override
             public List<LeafletEventType> getEvents() {
                 return events;
-            }            
+            }
         };
     }
-    
+
     private void registerListeners() {
-      eventsClasses.forEach(c -> {
-        addListener(c, e -> {
-          Layer layer = findLayer(e.getLayerId());
-          this.fireEvent(layer, e);
+        eventsClasses.forEach(c -> {
+            addListener(c, e -> {
+                Layer layer = findLayer(e.getLayerId());
+                this.fireEvent(layer, e);
+            });
         });
-      });
     }
-    
+
     @Override
     protected void onAttach(AttachEvent attachEvent) {
-      super.onAttach(attachEvent);
+        super.onAttach(attachEvent);
         // set events to leaflet 
         JsonArray jsonArray = Json.createArray();
         for (int i = 0; i < events.size(); i++) {
-          JsonObject js = Json.createObject();
-          js.put("leafletEvent", events.get(i).name());
-          jsonArray.set(i, js);
-        }   
-        this.getElement().setPropertyJson("events", jsonArray);        
+            JsonObject js = Json.createObject();
+            js.put("leafletEvent", events.get(i).name());
+            jsonArray.set(i, js);
+        }
+        this.getElement().setPropertyJson("events", jsonArray);
     }
 
     /**
      * Fires the given leaflet event
-     * 
-     * @param layer
-     *            the layer where the event occurred
-     * @param event
-     *            the event object to be propagate
+     * @param layer the layer where the event occurred
+     * @param event the event object to be propagate
      * @see LeafletEvent
      */
     private void fireEvent(Layer layer, LeafletEvent event) {
@@ -259,9 +259,7 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
 
     /**
      * Returns the layer with the given internal ID.
-     * 
-     * @param layerId
-     *            the id of the layer to be looking for
+     * @param layerId the id of the layer to be looking for
      * @return the layer with the given internal ID
      */
     public Layer getLayer(String layerId) {
@@ -274,9 +272,7 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
 
     /**
      * Adds the given layer to the map
-     * 
-     * @param layer
-     *            the layer to add
+     * @param layer the layer to add
      */
     public void addLayer(Layer layer) {
         logger.debug("add layer: {}", layer);
@@ -286,9 +282,7 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
 
     /**
      * Removes the given layer from the map.
-     * 
-     * @param layer
-     *            the layer to remove
+     * @param layer the layer to remove
      */
     public void removeLayer(Layer layer) {
         logger.debug("remove layer: {}", layer.getUuid());
@@ -302,9 +296,7 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
 
     /**
      * Adds the given control to the map
-     * 
-     * @param leafletControl
-     *            the control to add
+     * @param leafletControl the control to add
      */
     public void addControl(LeafletControl leafletControl) {
         executeJs("addControl", leafletControl);
@@ -312,9 +304,7 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
 
     /**
      * Removes the given control from the map
-     * 
-     * @param leafletControl
-     *            the control to remove
+     * @param leafletControl the control to remove
      */
     public void removeControl(LeafletControl leafletControl) {
         executeJs("removeControl", leafletControl);
@@ -323,9 +313,7 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
     /**
      * Fired when the map gets initialized with a view (center and zoom) and at
      * least one layer, or immediately if it's already initialized.
-     * 
-     * @param listener
-     *            the listener to call when the event occurs, not {@code null}
+     * @param listener the listener to call when the event occurs, not {@code null}
      * @return a handle that can be used for removing the listener
      */
     public Registration whenReady(ComponentEventListener<MapReadyEvent> listener) {
@@ -344,9 +332,7 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
 
     /**
      * Adds theme variants to the map component.
-     *
-     * @param variants
-     *            theme variants to add
+     * @param variants theme variants to add
      */
     public void addThemeVariants(LeafletMapVariant... variants) {
         getThemeNames().addAll(Stream.of(variants).map(LeafletMapVariant::getVariantName).collect(Collectors.toList()));
@@ -376,8 +362,7 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
                     if (type.equals(JsonType.OBJECT)) {
                         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
                         result = objectMapper.readValue(value.toString(), resultType);
-                    }
-                    else {
+                    } else {
                         result = objectMapper.readValue(value.asString(), resultType);
                     }
                     completableFuture.complete(result);
@@ -398,6 +383,15 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
     public <T extends LeafletEvent> void addEventListener(LeafletEventType eventType, LeafletEventListener<T> listener) {
         this.mapLayer.addEventListener(eventType, listener);
         this.getModel().getEvents().add(eventType);
+    }
+
+    @Override
+    public boolean removeEventListener(LeafletEventType eventType, LeafletEventListener<?> listener) {
+        boolean result = this.mapLayer.removeEventListener(eventType, listener);
+        if (result && this.mapLayer.hasEventListeners(eventType)) {
+            this.getModel().getEvents().remove(eventType);
+        }
+        return result;
     }
 
     @Override
@@ -431,11 +425,10 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
 
     /**
      * Map event which fired when map gets initialized on client side
-     * 
      * @author <strong>Gabor Kokeny</strong> Email:
-     *         <a href='mailto=kokeny19@gmail.com'>kokeny19@gmail.com</a>
-     * @since 2020-03-16
+     * <a href='mailto=kokeny19@gmail.com'>kokeny19@gmail.com</a>
      * @version 1.0
+     * @since 2020-03-16
      */
     public static final class MapReadyEvent extends ComponentEvent<LeafletMap> {
 
@@ -444,6 +437,5 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
         public MapReadyEvent(LeafletMap source) {
             super(source, true);
         }
-
     }
 }

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/events/Evented.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/events/Evented.java
@@ -47,6 +47,8 @@ public interface Evented {
 	 */
 	<T extends LeafletEvent> void addEventListener(LeafletEventType eventType, LeafletEventListener<T> listener);
 
+	boolean removeEventListener(LeafletEventType eventType, LeafletEventListener<?> listener);
+
 	/**
 	 * Alias to addEventListener(…)
 	 * 

--- a/src/main/resources/META-INF/resources/frontend/leaflet-map.js
+++ b/src/main/resources/META-INF/resources/frontend/leaflet-map.js
@@ -118,12 +118,17 @@ class LeafletMap extends ThemableMixin(PolymerElement) {
     let leafletFn = target[operation.functionName];
     // console.log("LeafletMap - callLeafletFunction() - leafletFn", leafletFn);
 
+    // we want to call registerEventListener, that is a function of this file, not a function on leaflet Map object
+    if (!leafletFn && "registerEventListener" === operation.functionName) {
+        this.registerEventListener(leafletArgs[0], leafletArgs[1]);
+    }
+
     if(leafletFn){
       let result = leafletFn.apply(target, leafletArgs);
       // console.log("LeafletMap - callLeafletFunction() - result", result);
       return result;
-    } 
-    
+    }
+
     return;
   }
 
@@ -280,11 +285,11 @@ class LeafletMap extends ThemableMixin(PolymerElement) {
   }
 
   onMouseEventEventHandler(event) {
-    console.info("LeafletMap - onMouseEventEventHandler()", event);    
+    console.info("LeafletMap - onMouseEventEventHandler()", event);
     this.dispatchEvent( new CustomEvent("leaflet-"+ event.type, { detail: event }));
   }
   onKeyboardEventHandler(event) {
-    console.info("LeafletMap - onKeyboardEventHandler()", event);    
+    console.info("LeafletMap - onKeyboardEventHandler()", event);
     this.dispatchEvent( new CustomEvent("leaflet-"+ event.type, { detail: event }));
   }
   onResizeEventHandler(event) {

--- a/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/marker/MarkersEventsExample.java
+++ b/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/marker/MarkersEventsExample.java
@@ -15,58 +15,82 @@
 package org.vaadin.addons.componentfactory.leaflet.demo.view.marker;
 
 import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
+import lombok.extern.slf4j.Slf4j;
 import org.vaadin.addons.componentfactory.leaflet.LeafletMap;
 import org.vaadin.addons.componentfactory.leaflet.demo.LeafletDemoApp;
 import org.vaadin.addons.componentfactory.leaflet.demo.components.ExampleContainer;
+import org.vaadin.addons.componentfactory.leaflet.layer.Layer;
 import org.vaadin.addons.componentfactory.leaflet.layer.events.LeafletEvent;
+import org.vaadin.addons.componentfactory.leaflet.layer.events.LeafletEventListener;
+import org.vaadin.addons.componentfactory.leaflet.layer.events.MouseEvent;
+import org.vaadin.addons.componentfactory.leaflet.layer.events.types.LeafletEventType;
+import org.vaadin.addons.componentfactory.leaflet.layer.events.types.MouseEventType;
 import org.vaadin.addons.componentfactory.leaflet.layer.map.options.DefaultMapOptions;
 import org.vaadin.addons.componentfactory.leaflet.layer.map.options.MapOptions;
 import org.vaadin.addons.componentfactory.leaflet.layer.ui.marker.Marker;
 import org.vaadin.addons.componentfactory.leaflet.types.LatLng;
+import com.vaadin.flow.component.button.Button;
 
+@Slf4j
 @PageTitle("Marker events")
 @Route(value = "marker/events", layout = LeafletDemoApp.class)
 public class MarkersEventsExample extends ExampleContainer {
 
-	private Label eventLabel;
+    private Label eventLabel;
 
-	@Override
-	protected void initDemo() {
+    @Override
+    protected void initDemo() {
 
-		eventLabel = new Label();
-		eventLabel.getStyle().set("font-weight", "bold");
+        eventLabel = new Label();
+        eventLabel.getStyle().set("font-weight", "bold");
+        Button buttonAdd = new Button("Add click listener later");
+        Button buttonRemove = new Button("Remove listener");
+        HorizontalLayout buttonLayout = new HorizontalLayout(buttonAdd, buttonRemove);
 
-		MapOptions options = new DefaultMapOptions();
-		options.setCenter(new LatLng(47.070121823, 19.2041015625));
-		options.setZoom(7);
-		LeafletMap leafletMap = new LeafletMap(options);
-		leafletMap.setBaseUrl("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png");
+        MapOptions options = new DefaultMapOptions();
+        options.setCenter(new LatLng(47.070121823, 19.2041015625));
+        options.setZoom(7);
+        LeafletMap leafletMap = new LeafletMap(options);
+        leafletMap.setBaseUrl("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png");
 
-		Marker marker = new Marker(new LatLng(46.470121823, 18.3041015625));
-		marker.setDraggable(true);
-		marker.bindPopup("Hi, I'am an interactive marker!");
-		marker.bindTooltip("hey, drag me if you want.");
-		marker.onClick(this::logEvent);
-		marker.onAdd(this::logEvent);
-		marker.onDoubleClick(this::logEvent);
-		marker.onPopupOpen(this::logEvent);
-		marker.onPopupClose(this::logEvent);
-		marker.onTooltipOpen(this::logEvent);
-		marker.onTooltipClose(this::logEvent);
-		marker.onDragStart(this::logEvent);
-		marker.onDragEnd(this::logEvent);
-		marker.onDrag(this::logEvent);
-		marker.onContextMenuOpened(this::logEvent);
-		marker.onMouseDown(this::logEvent);
-		marker.onMouseUp(this::logEvent);
-		marker.addTo(leafletMap);
+        final Marker marker = new Marker(new LatLng(46.470121823, 18.3041015625));
+        marker.setDraggable(true);
+        marker.bindPopup("Hi, I'am an interactive marker!");
+        marker.bindTooltip("hey, drag me if you want.");
+        //		marker.onClick(this::logEvent);
+        marker.onAdd(this::logEvent);
+        marker.onDoubleClick(this::logEvent);
+        marker.onPopupOpen(this::logEvent);
+        marker.onPopupClose(this::logEvent);
+        marker.onTooltipOpen(this::logEvent);
+        marker.onTooltipClose(this::logEvent);
+        marker.onDragStart(this::logEvent);
+        marker.onDragEnd(this::logEvent);
+        marker.onDrag(this::logEvent);
+        marker.onContextMenuOpened(this::logEvent);
+        marker.onMouseDown(this::logEvent);
+        marker.onMouseUp(this::logEvent);
+        marker.addTo(leafletMap);
 
-		addToContent(eventLabel, leafletMap);
-	}
+        addToContent(eventLabel, buttonLayout, leafletMap);
 
-	protected void logEvent(LeafletEvent leafletEvent) {
-		this.eventLabel.setText("'" + leafletEvent.getType().name() + "' event caught in listener.");
-	}
+        LeafletEventListener<MouseEvent> logClickEvent = this::logClickEvent;
+        buttonAdd.addClickListener(e -> marker.onClick(logClickEvent));
+        buttonRemove.addClickListener(e -> marker.removeEventListener(MouseEventType.click, logClickEvent));
+    }
+
+    protected void logEvent(LeafletEvent leafletEvent) {
+        this.eventLabel.setText("'" + leafletEvent.getType().name() + "' event caught in listener.");
+    }
+
+    protected void logClickEvent(LeafletEvent leafletEvent) {
+        this.eventLabel.setText("'This is the only click listener and was added later" +
+                leafletEvent.getType().name() + "' event caught in listener.");
+        log.info("Clicked on marker and this listener was added later");
+        Notification.show("Clicked on marker and this listener was added later");
+    }
 }


### PR DESCRIPTION
- LeafletMap formatting
- and added a method removeEventListener to remove only a specific Listener
- Layer:  now adding a Listener informs the Map correctly
- MarkersEventsExample lets us try to add a listener and remove it