### PR TITLE
Closes VL-18 included geoman

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,9 @@
 				<executions>
 					<execution>
 						<goals>
+							<!-- https://vaadin.com/docs/latest/flow/production/production-build#prepare-frontend -->
 							<goal>prepare-frontend</goal>
+						  	<!--goal>build-frontend</goal-->
 						</goals>
 					</execution>
 				</executions>

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/LeafletMap.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/LeafletMap.java
@@ -27,78 +27,7 @@ package org.vaadin.addons.componentfactory.leaflet;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.vaadin.addons.componentfactory.leaflet.controls.LeafletControl;
-import org.vaadin.addons.componentfactory.leaflet.layer.Identifiable;
-import org.vaadin.addons.componentfactory.leaflet.layer.Layer;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.AddEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.BaseLayerChangeEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.DragEndEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.DragEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.ErrorEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.KeyDownEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.KeyPressEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.KeyUpEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.LayerAddEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.LayerRemoveEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.LeafletEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.LeafletEventListener;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.LoadEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.LocationEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.MouseClickEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.MouseContextMenuEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.MouseDoubleClickEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.MouseDownEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.MouseMoveEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.MouseOutEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.MouseOverEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.MousePreClickEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.MouseUpEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.MoveEndEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.MoveStartEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.OverlayAddEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.OverlayRemoveEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.PopupCloseEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.PopupOpenEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.RemoveEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.ResizeEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.TileErrorEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.TileLoadEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.TileLoadStartEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.TileUnloadEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.TooltipCloseEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.TooltipOpenEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.UnloadEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.ViewResetEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.ZoomAnimEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.ZoomEndEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.ZoomEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.ZoomLevelsChangeEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.ZoomStartEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.supports.SupportsKeyboardEvents;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.supports.SupportsLayerEvents;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.supports.SupportsLocationEvents;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.supports.SupportsMapEvents;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.supports.SupportsMouseEvents;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.types.LeafletEventType;
-import org.vaadin.addons.componentfactory.leaflet.layer.groups.LayerGroup;
-import org.vaadin.addons.componentfactory.leaflet.layer.map.functions.GeolocationFunctions;
-import org.vaadin.addons.componentfactory.leaflet.layer.map.functions.MapConversionFunctions;
-import org.vaadin.addons.componentfactory.leaflet.layer.map.functions.MapGetStateFunctions;
-import org.vaadin.addons.componentfactory.leaflet.layer.map.functions.MapModifyStateFunctions;
-import org.vaadin.addons.componentfactory.leaflet.layer.map.options.DefaultMapOptions;
-import org.vaadin.addons.componentfactory.leaflet.layer.map.options.MapOptions;
-import org.vaadin.addons.componentfactory.leaflet.layer.raster.TileLayer;
-import org.vaadin.addons.componentfactory.leaflet.operations.LeafletOperation;
-import com.vaadin.flow.component.AttachEvent;
-import com.vaadin.flow.component.ClientCallable;
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentEvent;
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentUtil;
-import com.vaadin.flow.component.HasSize;
-import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.HasTheme;
-import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.*;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -110,27 +39,45 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.JsonType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.vaadin.addons.componentfactory.leaflet.controls.LeafletControl;
+import org.vaadin.addons.componentfactory.leaflet.layer.Identifiable;
+import org.vaadin.addons.componentfactory.leaflet.layer.Layer;
+import org.vaadin.addons.componentfactory.leaflet.layer.events.KeyDownEvent;
+import org.vaadin.addons.componentfactory.leaflet.layer.events.KeyPressEvent;
+import org.vaadin.addons.componentfactory.leaflet.layer.events.KeyUpEvent;
+import org.vaadin.addons.componentfactory.leaflet.layer.events.*;
+import org.vaadin.addons.componentfactory.leaflet.layer.events.supports.*;
+import org.vaadin.addons.componentfactory.leaflet.layer.events.types.LeafletEventType;
+import org.vaadin.addons.componentfactory.leaflet.layer.groups.LayerGroup;
+import org.vaadin.addons.componentfactory.leaflet.layer.map.functions.GeolocationFunctions;
+import org.vaadin.addons.componentfactory.leaflet.layer.map.functions.MapConversionFunctions;
+import org.vaadin.addons.componentfactory.leaflet.layer.map.functions.MapGetStateFunctions;
+import org.vaadin.addons.componentfactory.leaflet.layer.map.functions.MapModifyStateFunctions;
+import org.vaadin.addons.componentfactory.leaflet.layer.map.options.DefaultMapOptions;
+import org.vaadin.addons.componentfactory.leaflet.layer.map.options.MapOptions;
+import org.vaadin.addons.componentfactory.leaflet.layer.raster.TileLayer;
+import org.vaadin.addons.componentfactory.leaflet.operations.LeafletOperation;
+import org.vaadin.addons.componentfactory.leaflet.types.CustomSimpleCrs;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.vaadin.addons.componentfactory.leaflet.types.CustomSimpleCrs;
-
 @Tag("leaflet-map")
 @NpmPackage(value = "leaflet", version = "1.9.4")
-@JsModule("./leaflet-map.js")
 @JsModule("leaflet/dist/leaflet-src.js")
+@JsModule("./leaflet-map.js")
 @CssImport(value = "leaflet/dist/leaflet.css", themeFor = "leaflet-map")
+@CssImport(value = "@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.css", themeFor = "leaflet-map")
 @CssImport(value = "./styles/leaflet-lumo-theme.css", themeFor = "leaflet-map")
+@NpmPackage(value="@geoman-io/leaflet-geoman-free", version = "2.14.2")
 public final class LeafletMap extends Component implements MapModifyStateFunctions, MapGetStateFunctions, GeolocationFunctions, MapConversionFunctions, SupportsMouseEvents,
         SupportsMapEvents, SupportsLocationEvents, SupportsKeyboardEvents, SupportsLayerEvents, HasSize, HasTheme, HasStyle {
 

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/geoman/options/GeomanControlOptions.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/geoman/options/GeomanControlOptions.java
@@ -1,0 +1,35 @@
+package org.vaadin.addons.componentfactory.leaflet.plugins.geoman.options;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.vaadin.addons.componentfactory.leaflet.layer.map.options.ControlOptions;
+
+/**
+ * Options to initialize geoman control toolbar.
+ * See <a href="https://geoman.io/docs/leaflet/toolbar">geoman options</a>
+ */
+@Getter
+@Setter
+public class GeomanControlOptions implements ControlOptions {
+
+    private boolean zoomControl;
+    private boolean attributionControl;
+
+    private String position = "topleft"; // Toolbar position, possible values are 'topleft', 'topright', 'bottomleft', 'bottomright'
+    private boolean drawMarker = true; //Adds button to draw Markers.
+    private boolean drawCircleMarker = true; //Adds button to draw CircleMarkers.
+    private boolean drawPolyline = true; //Adds button to draw Line.
+    private boolean drawRectangle = true; //Adds button to draw Rectangle.
+    private boolean drawPolygon = true; //Adds button to draw Polygon.
+    private boolean drawCircle = true; //Adds button to draw Circle.
+    private boolean drawText = true; //Adds button to draw Text.
+    private boolean editMode = true; //Adds button to toggle Edit Mode for all layers.
+    private boolean dragMode = true; //Adds button to toggle Drag Mode for all layers.
+    private boolean cutPolygon = true; //Adds button to cut a hole in a Polygon or Line.
+    private boolean removalMode = true; //Adds a button to remove layers.
+    private boolean rotateMode = true; //Adds a button to rotate layers.
+    private boolean oneBlock = false; //All buttons will be displayed as one block Customize Controls.
+    private boolean drawControls = true; //Shows all draw buttons / buttons in the draw block.
+    private boolean editControls = true; //Shows all edit buttons / buttons in the edit block.
+    private boolean customControls = true; //Shows all buttons in the custom block.
+}

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/geoman/options/GeomanUtils.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/geoman/options/GeomanUtils.java
@@ -1,0 +1,14 @@
+package org.vaadin.addons.componentfactory.leaflet.plugins.geoman.options;
+
+import org.vaadin.addons.componentfactory.leaflet.LeafletMap;
+
+/**
+ * <h2>Leaflet.geoman</h2> Leaflet Plugin For Creating And Editing Geometry Layers.
+ * <a href="https://github.com/geoman-io/leaflet-geoman">leaflet.geoman</a>
+ */
+public class GeomanUtils {
+
+    public static void addControls(LeafletMap leafletMap, GeomanControlOptions options) {
+        leafletMap.executeJs(leafletMap, "pm.addControls", options);
+    }
+}

--- a/src/main/resources/META-INF/resources/frontend/leaflet-base.js
+++ b/src/main/resources/META-INF/resources/frontend/leaflet-base.js
@@ -1,0 +1,8 @@
+import * as L from "leaflet/dist/leaflet-src.js";
+
+globalThis.L = {};
+for (const [key, value] of Object.entries(L)) {
+    globalThis.L[key] = value;
+}
+
+import "leaflet/dist/leaflet.css";

--- a/src/main/resources/META-INF/resources/frontend/leaflet-more.js
+++ b/src/main/resources/META-INF/resources/frontend/leaflet-more.js
@@ -1,0 +1,2 @@
+import "@geoman-io/leaflet-geoman-free";
+import "@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.css";

--- a/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/LeafletDemoApp.java
+++ b/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/LeafletDemoApp.java
@@ -37,10 +37,7 @@ import com.vaadin.flow.router.AfterNavigationObserver;
 
 import org.vaadin.addons.componentfactory.leaflet.demo.components.AppMenu;
 import org.vaadin.addons.componentfactory.leaflet.demo.components.AppMenuItem;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.controls.ControlPositionExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.controls.LayersControlExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.controls.RemoveDefaultControlsExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.controls.ScaleControlExample;
+import org.vaadin.addons.componentfactory.leaflet.demo.view.controls.*;
 import org.vaadin.addons.componentfactory.leaflet.demo.view.layers.MultipleBaseLayersExample;
 import org.vaadin.addons.componentfactory.leaflet.demo.view.map.*;
 import org.vaadin.addons.componentfactory.leaflet.demo.view.marker.DivOverlayStyleExample;
@@ -59,13 +56,7 @@ import org.vaadin.addons.componentfactory.leaflet.demo.view.path.Paths3000Exampl
 import org.vaadin.addons.componentfactory.leaflet.demo.view.path.PathsEventPropagationExample;
 import org.vaadin.addons.componentfactory.leaflet.demo.view.path.PathsStyleExample;
 import org.vaadin.addons.componentfactory.leaflet.demo.view.path.TypeOfPathsExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.plugins.DynamicMapLayerPluginExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.plugins.FullScreenPluginExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.plugins.HeatmapPluginExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.plugins.KmzLayerPluginExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.plugins.MarkerClusterPluginExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.plugins.TiledMapLayerPluginExample;
-import org.vaadin.addons.componentfactory.leaflet.demo.view.plugins.VectorBasemapLayerPluginExample;
+import org.vaadin.addons.componentfactory.leaflet.demo.view.plugins.*;
 
 @CssImport(value = "styles/demo-applayout.css", themeFor = "vaadin-app-layout")
 public class LeafletDemoApp extends AppLayout implements AfterNavigationObserver {
@@ -148,6 +139,8 @@ public class LeafletDemoApp extends AppLayout implements AfterNavigationObserver
                 .addSubMenu(DynamicMapLayerPluginExample.class)
                 .addSubMenu(TiledMapLayerPluginExample.class)
                 .addSubMenu(VectorBasemapLayerPluginExample.class)
+                .addSubMenu(PrintControlExample.class)
+                .addSubMenu(GeomanEditMapPluginExample.class)
                 .addTo(appMenu);
 
         addToDrawer(appMenu);

--- a/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/plugins/GeomanEditMapPluginExample.java
+++ b/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/plugins/GeomanEditMapPluginExample.java
@@ -1,4 +1,4 @@
-package org.vaadin.addons.componentfactory.leaflet.demo.view.map;
+package org.vaadin.addons.componentfactory.leaflet.demo.view.plugins;
 
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.PageTitle;
@@ -10,17 +10,17 @@ import org.vaadin.addons.componentfactory.leaflet.layer.groups.LayerGroup;
 import org.vaadin.addons.componentfactory.leaflet.layer.map.options.DefaultMapOptions;
 import org.vaadin.addons.componentfactory.leaflet.layer.map.options.MapOptions;
 import org.vaadin.addons.componentfactory.leaflet.layer.ui.marker.Marker;
+import org.vaadin.addons.componentfactory.leaflet.plugins.geoman.options.GeomanControlOptions;
+import org.vaadin.addons.componentfactory.leaflet.plugins.geoman.options.GeomanUtils;
 import org.vaadin.addons.componentfactory.leaflet.types.Icon;
 
 import static java.util.stream.IntStream.range;
+import static org.vaadin.addons.componentfactory.leaflet.types.Icon.DEFAULT_ICON;
 import static org.vaadin.addons.componentfactory.leaflet.types.LatLng.latlng;
 
-@PageTitle("Multiple maps")
-@Route(value = "map/multiple", layout = LeafletDemoApp.class)
-public class MultipleMapsExample extends ExampleContainer {
-
-    private static Icon CUSTOM_ICON = new Icon("images/marker-icon-demo.png", 41);
-
+@PageTitle("Editable map")
+@Route(value = "plugin/geoman", layout = LeafletDemoApp.class)
+public class GeomanEditMapPluginExample extends ExampleContainer {
     @Override
     protected void initDemo() {
         MapOptions options = new DefaultMapOptions();
@@ -28,19 +28,22 @@ public class MultipleMapsExample extends ExampleContainer {
         options.setZoom(7);
         options.setPreferCanvas(true);
 
-
-        LeafletMap leafletMapLeft = new LeafletMap(options);
-        leafletMapLeft.setBaseUrl("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png");
-        leafletMapLeft.addLayer(createRandomMarkers(Icon.DEFAULT_ICON, 30));
-
         LeafletMap leafletMapRight = new LeafletMap(options);
         leafletMapRight.setBaseUrl("https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png");
-        leafletMapRight.addLayer(createRandomMarkers(CUSTOM_ICON, 30));
+        leafletMapRight.addLayer(createRandomMarkers(DEFAULT_ICON, 30));
 
         HorizontalLayout horizontalLayout = new HorizontalLayout();
         horizontalLayout.setSizeFull();
-        horizontalLayout.add(leafletMapLeft, leafletMapRight);
+        horizontalLayout.add(leafletMapRight);
         addToContent(horizontalLayout);
+
+        GeomanControlOptions geomanControlOptions = new GeomanControlOptions();
+        geomanControlOptions.setCutPolygon(false);
+        geomanControlOptions.setDrawPolygon(false);
+        geomanControlOptions.setDrawCircle(false);
+        GeomanUtils.addControls(leafletMapRight, geomanControlOptions);
+
+
     }
 
     private LayerGroup createRandomMarkers(Icon icon, int limit) {


### PR DESCRIPTION
we use version 2.14.2 (2.18.0 npm module is not imported correctly).
- GeomanUtils will include methods to control Geoman plugin
- GeomanControlOptions to configure Geoman toolbar
- GeomanEditMapPluginExample is a View that shows Geoman toolbar

To work around problems with the inclusions of the web-component I created two more Javascript files to have Leaflet L object visible and usable (there is a link in the code with the details).

In a separate YouTrack issue (19) we will implement events management for creation and editing of layers.