### PR TITLE
Closes VL-24 adding listeners later works for map too

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.vaadin.addons.antea</groupId>
 	<artifactId>vcf-leaflet</artifactId>
-	<version>23.4.0.3-ANTEA</version>
+	<version>23.4.0.4-ANTEA-SNAPSHOT</version>
 	<name>Leaflet</name>
 	<description>Integration of Leaflet Map for Vaadin Flow</description>
 	<scm>

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/Layer.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/Layer.java
@@ -14,26 +14,11 @@
 
 package org.vaadin.addons.componentfactory.leaflet.layer;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-
 import lombok.Getter;
 import lombok.Setter;
 import org.vaadin.addons.componentfactory.leaflet.LeafletMap;
 import org.vaadin.addons.componentfactory.leaflet.LeafletObject;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.Evented;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.LeafletEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.LeafletEventListener;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.PopupEvent;
-import org.vaadin.addons.componentfactory.leaflet.layer.events.TooltipEvent;
+import org.vaadin.addons.componentfactory.leaflet.layer.events.*;
 import org.vaadin.addons.componentfactory.leaflet.layer.events.types.LeafletEventType;
 import org.vaadin.addons.componentfactory.leaflet.layer.events.types.PopupEventType;
 import org.vaadin.addons.componentfactory.leaflet.layer.events.types.TooltipEventType;
@@ -41,6 +26,11 @@ import org.vaadin.addons.componentfactory.leaflet.layer.groups.LayerGroup;
 import org.vaadin.addons.componentfactory.leaflet.layer.map.functions.ExecutableFunctions;
 import org.vaadin.addons.componentfactory.leaflet.layer.ui.popup.Popup;
 import org.vaadin.addons.componentfactory.leaflet.layer.ui.tooltip.Tooltip;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * A set of methods from the Layer base class that all Leaflet layers use.
@@ -220,8 +210,7 @@ public abstract class Layer extends LeafletObject implements Evented, LayerPopup
             // listener for these kind of events, so now we tell the map to start listening for them
             if (getParent() != null) {
                 findLeafletMap(this)
-                        .ifPresent(map ->
-                                map.executeJs("registerEventListener", Layer.this, eventType.getLeafletEvent()));
+                        .ifPresent(map -> doRegisterEventListener(this, map, eventType));
             }
             events.add(eventType.getLeafletEvent());
         }
@@ -231,6 +220,10 @@ public abstract class Layer extends LeafletObject implements Evented, LayerPopup
             eventListeners.putIfAbsent(eventType, listeners);
         }
         listeners.add(listener);
+    }
+
+    protected void doRegisterEventListener(Identifiable target, LeafletMap leafletMap, LeafletEventType eventType) {
+        leafletMap.executeGeneralJs(target, "registerMapEventListener", eventType.getLeafletEvent());
     }
 
     @Override

--- a/src/main/resources/META-INF/resources/frontend/leaflet-map.js
+++ b/src/main/resources/META-INF/resources/frontend/leaflet-map.js
@@ -154,9 +154,6 @@ class LeafletMap extends ThemableMixin(PolymerElement) {
       let result = leafletFn.apply(target, leafletArgs);
       // console.log("LeafletMap - callLeafletFunction() - result", result);
       return result;
-    } else if ("registerEventListener" === operation.functionName) {
-      // we want to call registerEventListener, that is a function of this file, not a function on leaflet Map object
-      this.registerEventListener(leafletArgs[0], leafletArgs[1]);
     } else if (operation.functionName.startsWith("pm")) {
       this._callPMFunction(operation.functionName, leafletArgs);
     }
@@ -236,6 +233,10 @@ class LeafletMap extends ThemableMixin(PolymerElement) {
     return leafletMap;
   }
 
+  registerMapEventListener(layer, events) {
+    this.registerEventListener(layer, events[0]);
+  }
+
   registerEventListener(layer, event) {
     let found = this.getEventMap().find((e) => e.events.indexOf(event) >= 0);
     let eventListener = this.onBaseEventHandler;
@@ -248,6 +249,7 @@ class LeafletMap extends ThemableMixin(PolymerElement) {
       "LeafletMap - registerEventListener() register listener for event",
       { event: event }
     );
+
     layer.on(event, eventListener, this);
    }
 

--- a/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/marker/MarkersEventsExample.java
+++ b/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/marker/MarkersEventsExample.java
@@ -49,7 +49,9 @@ public class MarkersEventsExample extends ExampleContainer {
         eventLabel.getStyle().set("font-weight", "bold");
         Button buttonAdd = new Button("Add click listener later");
         Button buttonRemove = new Button("Remove listener");
-        HorizontalLayout buttonLayout = new HorizontalLayout(buttonAdd, buttonRemove);
+        Button buttonAddToMap = new Button("Add click listener to Map later");
+        Button buttonRemoveFromMap = new Button("Remove listener from Map");
+        HorizontalLayout buttonLayout = new HorizontalLayout(buttonAdd, buttonRemove, buttonAddToMap, buttonRemoveFromMap);
 
         MapOptions options = new DefaultMapOptions();
         options.setCenter(new LatLng(47.070121823, 19.2041015625));
@@ -81,6 +83,9 @@ public class MarkersEventsExample extends ExampleContainer {
         LeafletEventListener<MouseEvent> logClickEvent = this::logClickEvent;
         buttonAdd.addClickListener(e -> marker.onClick(logClickEvent));
         buttonRemove.addClickListener(e -> marker.removeEventListener(MouseEventType.click, logClickEvent));
+
+        buttonAddToMap.addClickListener(e -> leafletMap.onClick(logClickEvent));
+        buttonRemoveFromMap.addClickListener(e -> leafletMap.removeEventListener(MouseEventType.click, logClickEvent));
     }
 
     protected void logEvent(LeafletEvent leafletEvent) {
@@ -90,7 +95,7 @@ public class MarkersEventsExample extends ExampleContainer {
     protected void logClickEvent(LeafletEvent leafletEvent) {
         this.eventLabel.setText("'This is the only click listener and was added later" +
                 leafletEvent.getType().name() + "' event caught in listener.");
-        log.info("Clicked on marker and this listener was added later");
-        Notification.show("Clicked on marker and this listener was added later");
+        log.info("Clicked and this listener was added later");
+        Notification.show("Clicked and this listener was added later");
     }
 }


### PR DESCRIPTION
MapLayer is not serialized to the client, so my previous modifications for VL 17 where not working for listeners added to map.
Now we correctly register listeners on the map on the client.