### PR TITLE
VL-27 adding a layer before its parent works correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.vaadin.addons.antea</groupId>
 	<artifactId>vcf-leaflet</artifactId>
-	<version>23.4.0.5-ANTEA</version>
+	<version>23.4.0.6-ANTEA-SNAPSHOT</version>
 	<name>Leaflet</name>
 	<description>Integration of Leaflet Map for Vaadin Flow</description>
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.vaadin.addons.antea</groupId>
 	<artifactId>vcf-leaflet</artifactId>
-	<version>23.4.0.5-ANTEA-SNAPSHOT</version>
+	<version>23.4.0.5-ANTEA</version>
 	<name>Leaflet</name>
 	<description>Integration of Leaflet Map for Vaadin Flow</description>
 	<scm>

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/LeafletMap.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/LeafletMap.java
@@ -87,13 +87,29 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
 
     private final Logger logger = LoggerFactory.getLogger(LeafletMap.class);
 
-    private static class MapLayer extends LayerGroup {
+    public static class MapLayer extends LayerGroup {
         private static final long serialVersionUID = -3205153902141978918L;
         private final transient LeafletMap leafletMap;
 
         public MapLayer(LeafletMap leafletMap) {
             super();
             this.leafletMap = leafletMap;
+        }
+
+        @Override
+        public void removeLayer(Layer layer) {
+            super.removeLayer(layer);
+            leafletMap.executeJs("removeLayer", layer);
+        }
+
+        @Override
+        public void executeJs(String functionName, Serializable... arguments) {
+            executeJs(leafletMap, functionName, arguments);
+        }
+
+        @Override
+        public <T extends Serializable> CompletableFuture<T> call(String functionName, Class<T> resultType, Serializable... arguments) {
+            return super.call(leafletMap, functionName, resultType, arguments);
         }
 
         @Override
@@ -201,10 +217,11 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
                 // if the layer was created by geoman, we fire also a layerAdd event with the new layer
                 if (e instanceof ClientLayerAddEvent) {
                     ClientLayerAddEvent clientLayerAddEvent = (ClientLayerAddEvent) e;
+                    Layer parent = findLayer(clientLayerAddEvent.getParentLayerId());
+                    Layer child = GeomanUtils.syncCreatedLayer(clientLayerAddEvent, parent);
+
                     LayerAddEvent layerAddEvent = new LayerAddEvent(clientLayerAddEvent.getSource(), true,
                             clientLayerAddEvent.getLayerId(), clientLayerAddEvent.getNewLayerId());
-
-                    Layer child = GeomanUtils.syncCreatedLayer(clientLayerAddEvent, layer);
                     layerAddEvent.setChild(child);
                     clientLayerAddEvent.setChild(child);
 
@@ -291,12 +308,11 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
      */
     public void replaceLayer(String oldLayerUuid, Layer newLayer) {
         this.mapLayer.findLayer(oldLayerUuid).ifPresent(oldLayer -> {
+            oldLayer.remove();
             ExecutableFunctions parent = oldLayer.getParent();
             if (Objects.equals(mapLayer, parent)) {
-                removeLayer(oldLayer);
                 addLayer(newLayer);
             } else if (parent instanceof LayerGroup) {
-                ((LayerGroup) parent).removeLayer(oldLayer);
                 ((LayerGroup) parent).addLayer(newLayer);
             }
         });

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/geoman/GeomanUtils.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/geoman/GeomanUtils.java
@@ -129,14 +129,14 @@ public class GeomanUtils {
      * Please note that at the moment we support the creation only of Marker, Text, CircleMarker, PolyLine and
      * Rectangle.</b>
      * @param event The event that was raised by the client
-     * @param layer The layer in which the new layer was created.
+     * @param parent The layer in which the new layer was created.
      * @return the new Layer server side, and sync the server map to the client Leaflet map
      */
-    public static Layer syncCreatedLayer(ClientLayerAddEvent event, Layer layer) {
-        if (!(layer instanceof LayerGroup)) {
+    public static Layer syncCreatedLayer(ClientLayerAddEvent event, Layer parent) {
+        if (!(parent instanceof LayerGroup)) {
             return null;
         }
-        LayerGroup parentLayer = (LayerGroup) layer;
+        LayerGroup parentLayer = (LayerGroup) parent;
 
         return Optional.ofNullable(event)
                 .map(GeomanUtils::createLayer)

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/geoman/events/ClientLayerAddEvent.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/geoman/events/ClientLayerAddEvent.java
@@ -47,6 +47,7 @@ import static org.vaadin.addons.componentfactory.leaflet.plugins.geoman.GeomanUt
 @Getter
 @DomEvent("pm:create")
 public class ClientLayerAddEvent extends BaseClientLayerEvent {
+    private String parentLayerId;
 
     // if a Marker or Text or CircleMarker or a Circle was created, this is its coordinates
     private final LatLng latLng;
@@ -63,6 +64,7 @@ public class ClientLayerAddEvent extends BaseClientLayerEvent {
 
     public ClientLayerAddEvent(LeafletMap source, boolean fromClient,
             @EventData("event.detail.target.options.uuid") String targetLayerId,
+            @EventData("event.detail.parentLayer") String parentLayerId,
             // id of the new Layer, assigned by Leaflet
             @EventData("event.detail.layer._leaflet_id") String createdLayerId,
             @EventData("event.detail.layer._latlng") JsonValue latLng,
@@ -70,6 +72,7 @@ public class ClientLayerAddEvent extends BaseClientLayerEvent {
             @EventData("event.detail.layer._radius") Double radius,
             @EventData("event.detail.shape") String shape) {
         super(source, fromClient, EditEventType.create, targetLayerId, createdLayerId, ShapeType.ofGeomanShape(shape));
+        this.parentLayerId = parentLayerId != null ? parentLayerId: targetLayerId;
         this.radius = radius;
         this.latLng = readValue(latLng, new TypeReference<>() {});
         this.lineLatLngs = readValue(latLngs, new TypeReference<>() {});

--- a/src/main/resources/META-INF/resources/frontend/leaflet-map.js
+++ b/src/main/resources/META-INF/resources/frontend/leaflet-map.js
@@ -27,13 +27,12 @@ import {html, PolymerElement} from "@polymer/polymer/polymer-element.js";
 import {ThemableMixin} from "@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js";
 import './leaflet-base.js';
 import './leaflet-more.js'
-// https://github.com/geoman-io/leaflet-geoman/issues/1339
-export default globalThis.L;
-
 // import "@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.js"; for geoman > 1.15
 import "@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.min.js";
 
 import {LeafletTypeConverter} from "./leaflet-type-converter.js";
+// https://github.com/geoman-io/leaflet-geoman/issues/1339
+export default globalThis.L;
 
 class LeafletMap extends ThemableMixin(PolymerElement) {
   static get template() {
@@ -407,6 +406,7 @@ class LeafletMap extends ThemableMixin(PolymerElement) {
 
   onGeomanEventHandler(event) {
     console.info("LeafletMap - onGeomanEventHandler()", event);
+    event["parentLayer"] = this.map.pm.globalOptions?.layerGroup?.options.uuid;
     this.dispatchEvent(new CustomEvent(event.type, {detail: event}));
   }
 

--- a/src/main/resources/META-INF/resources/frontend/leaflet-type-converter.js
+++ b/src/main/resources/META-INF/resources/frontend/leaflet-type-converter.js
@@ -83,6 +83,11 @@ export class LeafletTypeConverter {
         map.registerEventListener(leafletLayer, event)
       );
     }
+
+    // if the layers where added on the server before the parent, let's force the id
+    if (layer.uuid && !(layer.uuid === layer._leaflet_id)) {
+      leafletLayer._leaflet_id = layer.uuid;
+    }
     // console.log("LeafletTypeConverter - toLeafletLayer() result", leafletLayer);
     return leafletLayer;
   }

--- a/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/plugins/GeomanEditMapPluginExample.java
+++ b/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/plugins/GeomanEditMapPluginExample.java
@@ -7,7 +7,10 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
+import lombok.extern.slf4j.Slf4j;
 import org.atmosphere.interceptor.AtmosphereResourceStateRecovery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.vaadin.addons.componentfactory.leaflet.LeafletMap;
 import org.vaadin.addons.componentfactory.leaflet.controls.LayersControl;
 import org.vaadin.addons.componentfactory.leaflet.demo.LeafletDemoApp;
@@ -24,6 +27,7 @@ import org.vaadin.addons.componentfactory.leaflet.plugins.geoman.events.types.Sh
 import org.vaadin.addons.componentfactory.leaflet.plugins.geoman.options.GeomanControlOptions;
 import org.vaadin.addons.componentfactory.leaflet.plugins.geoman.GeomanUtils;
 import org.vaadin.addons.componentfactory.leaflet.types.Icon;
+import org.vaadin.addons.componentfactory.leaflet.types.LatLng;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -32,6 +36,7 @@ import static java.util.stream.IntStream.range;
 import static org.vaadin.addons.componentfactory.leaflet.types.Icon.DEFAULT_ICON;
 import static org.vaadin.addons.componentfactory.leaflet.types.LatLng.latlng;
 
+@Slf4j
 @PageTitle("Editable map")
 @Route(value = "plugin/geoman", layout = LeafletDemoApp.class)
 public class GeomanEditMapPluginExample extends ExampleContainer {
@@ -44,7 +49,7 @@ public class GeomanEditMapPluginExample extends ExampleContainer {
 
         LeafletMap leafletMap = new LeafletMap(options);
         leafletMap.setBaseUrl("https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png");
-        leafletMap.addLayer(createRandomMarkers(DEFAULT_ICON, 4));
+       // leafletMap.addLayer(createRandomMarkers(DEFAULT_ICON, 4));
 
         leafletMap.onCreate(event -> {
             String newLayerId = event.getNewLayerId();
@@ -113,12 +118,40 @@ public class GeomanEditMapPluginExample extends ExampleContainer {
                 e ->
                         GeomanUtils.setDrawHandlersVisible(leafletMap, geomanControlOptions, e.getValue()));
 
+
+        Marker marker = new Marker(new LatLng(45,16));
+        marker.setIcon(new Icon("images/marker-icon-demo.png"));
+        marker.setAttribution("A marker");
+        log.error("created marker {}", marker.getUuid());
+        FeatureGroup ancestor = new FeatureGroup();
+        ancestor.setAttribution("Ancestor");
+        log.error("created ancestor {}", ancestor.getUuid());
+
+        FeatureGroup parent = new FeatureGroup();
+        parent.setAttribution("Parent");
+        log.error("created parent {}", parent.getUuid());
+
+        marker.addTo(parent);
+        parent.addTo(ancestor);
+        ancestor.addTo(leafletMap);
+
+        // OK all good
+//        ancestor.addTo(leafletMap);
+//        parent.addTo(ancestor);
+//        marker.addTo(parent);
+
+
+        Button deleteButton = new Button("Delete feature group");
+
+
         VerticalLayout verticalLayout = new VerticalLayout();
         verticalLayout.setSizeFull();
-        verticalLayout.add(new HorizontalLayout(editButton, drawPolygonButton, tryReplaceButton, editRemoveButton));
+        verticalLayout.add(new HorizontalLayout(editButton, drawPolygonButton, tryReplaceButton, editRemoveButton, deleteButton));
         verticalLayout.add(checkboxGroup);
         verticalLayout.add(leafletMap);
         addToContent(verticalLayout);
+
+        deleteButton.addClickListener(e -> marker.remove());
     }
 
     private LayerGroup createRandomMarkers(Icon icon, int limit) {


### PR DESCRIPTION
if a layer is created before the parent, it is not sent to the client (the Javascript function is not executed). So if we do

```
        Marker marker = new Marker(new LatLng(45,16));
        FeatureGroup ancestor = new FeatureGroup();
        FeatureGroup parent = new FeatureGroup();
    
        marker.addTo(parent);
        parent.addTo(ancestor);
        ancestor.addTo(leafletMap);
```

only the ancestor will launch the Javascript function addLayer(ancestor). The ancestor will be serialized with its descendants together, so we need to set the leafleat_id there, inside the Javascript converter.

