### PR TITLE
Closes VL-34 support grayscale for TileLayers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.vaadin.addons.antea</groupId>
 	<artifactId>vcf-leaflet</artifactId>
-	<version>23.4.0.10-ANTEA</version>
+	<version>23.4.0.11-ANTEA-SNAPSHOT</version>
 	<name>Leaflet</name>
 	<description>Integration of Leaflet Map for Vaadin Flow</description>
 	<scm>

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/LeafletMap.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/LeafletMap.java
@@ -434,9 +434,10 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
     }
 
     /**
-     * Attention, if the event is not a native LeafletEventType managed by the map, you need to call also {@link #registerListener(Class)}
+     * Attention, if the event is not a native LeafletEventType managed by the map, you need to call also
+     * {@link #registerListener(Class)}
      * @param eventType type of the event to be listening
-     * @param listener  the event listener
+     * @param listener the event listener
      * @param <T> the type of the event
      */
     @Override
@@ -512,5 +513,14 @@ public final class LeafletMap extends Component implements MapModifyStateFunctio
             event.setEditedLayer(layer);
             fireEvent(mapLayer, event);
         }
+    }
+
+    /**
+     * Set the TileLayer to grayscale if the map has a set id.
+     * @param addOrRemove true to set the TyleLayer to grayscale, false to disable
+     */
+    public void addOrRemoveGrayscaleInLeafletLayer(boolean addOrRemove) {
+        getElement().callJsFunction("addOrRemoveGrayscaleInLeafletLayer", addOrRemove);
+    }
     }
 }

--- a/src/main/resources/META-INF/resources/frontend/leaflet-map.js
+++ b/src/main/resources/META-INF/resources/frontend/leaflet-map.js
@@ -31,6 +31,7 @@ import './leaflet-more.js'
 import "@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.min.js";
 
 import {LeafletTypeConverter} from "./leaflet-type-converter.js";
+import {DomUtil} from "leaflet/dist/leaflet-src.esm";
 // https://github.com/geoman-io/leaflet-geoman/issues/1339
 export default globalThis.L;
 
@@ -452,6 +453,28 @@ class LeafletMap extends ThemableMixin(PolymerElement) {
       layer.on("pm:update", this.onLayerEditedOnClient, this);
     }
   }
+
+  /**
+   * Fit to the bounds that include all the layers inside
+
+  /**
+   * Let us make TileLayers grayscale
+   * @param add boolean, true will make the TileLayers grayscale
+   */
+  addOrRemoveGrayscaleInLeafletLayer = function (add) {
+    this.map.eachLayer(function (layer) {
+      if (layer instanceof L.TileLayer) {
+        const tileContainer = layer._container;
+        if (add)
+          DomUtil.addClass(tileContainer, 'grayscale')
+        else
+          DomUtil.removeClass(tileContainer, 'grayscale')
+      }
+    });
+  }
+
 }
 
 customElements.define(LeafletMap.is, LeafletMap);
+
+

--- a/src/main/resources/META-INF/resources/frontend/styles/leaflet-lumo-theme.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/leaflet-lumo-theme.css
@@ -102,3 +102,10 @@
   width: 80px;
   text-align: center;
 }
+
+/* Style for making TileLayers grayscale */
+.grayscale {
+  -webkit-filter: grayscale(100%);
+  -moz-filter: grayscale(100%);
+  filter: grayscale(100%);
+}

--- a/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/path/PathsStyleExample.java
+++ b/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/path/PathsStyleExample.java
@@ -48,7 +48,7 @@ public class PathsStyleExample extends ExampleContainer {
 		leafletMap.setBaseUrl("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png");
 
 		binder = new Binder<>(PathOptions.class);
-		createFormControls(binder);
+		createFormControls(leafletMap, binder);
 
 		binder.setBean(new PathOptions());
 
@@ -60,12 +60,12 @@ public class PathsStyleExample extends ExampleContainer {
 		addToContent(leafletMap);
 	}
 
-	private void createFormControls(Binder<PathOptions> binder) {
-		// Stroke control
-		FormLayout form = new FormLayout();
-		Checkbox checkbox = new Checkbox();
-		form.addFormItem(checkbox, "Stroke");
-		binder.forField(checkbox).bind("stroke");
+    private void createFormControls(LeafletMap map, Binder<PathOptions> binder) {
+        // Stroke control
+        FormLayout form = new FormLayout();
+        Checkbox checkbox = new Checkbox();
+        form.addFormItem(checkbox, "Stroke");
+        binder.forField(checkbox).bind("stroke");
 
 		Select<String> strokeColor = new Select<>();
 		strokeColor.setItems("red", "blue", "white", "green", "yellow", "gray", "black");
@@ -109,7 +109,13 @@ public class PathsStyleExample extends ExampleContainer {
 		});
 		form.add(reset);
 
-		addToSidebar(form);
-	}
 
+        Checkbox grayScaleCheckbox = new Checkbox("Grayscale");
+        grayScaleCheckbox.addValueChangeListener((event) -> {
+            map.addOrRemoveGrayscaleInLeafletLayer(event.getValue());
+        });
+        form.add(grayScaleCheckbox);
+
+        addToSidebar(form);
+    }
 }


### PR DESCRIPTION
To enable grayscale we need to change the CSS, and since it is inside the shadow DOM we cannot do it outside.

So I have added this functionality here.

Screenshot in YT