### PR TITLE
Closes VL-33 Adds method to disable drawing mode

### DIFF
--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/geoman/GeomanUtils.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/plugins/geoman/GeomanUtils.java
@@ -59,6 +59,15 @@ public class GeomanUtils {
     }
 
     /**
+     * Disables the drawing mode on the specified Leaflet map.
+     *
+     * @param leafletMap the Leaflet map on which to disable drawing mode
+     */
+    public static void disableDraw(LeafletMap leafletMap) {
+        leafletMap.executeJs(leafletMap, "pm.disableDraw");
+    }
+
+    /**
      * We can specify the icon to be used for marker creation
      * @param leafletMap LeafletMap to be modified
      * @param icon the new icon for markers

--- a/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/plugins/GeomanEditMapPluginExample.java
+++ b/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/plugins/GeomanEditMapPluginExample.java
@@ -115,6 +115,7 @@ public class GeomanEditMapPluginExample extends ExampleContainer {
                 if (ShapeType.MARKER.equals(e.getShape())) {
                     CircleMarker marker = new CircleMarker(e.getLatLng());
                     leafletMap.replaceLayer(e.getChild().getUuid(), marker);
+                    GeomanUtils.disableDraw(leafletMap);
                 }
             });
         });


### PR DESCRIPTION
Adds a utility method to disable drawing mode on a Leaflet map. This is used to prevent further drawing after a shape is created, such as when a marker is created on the map.

[VL-33](https://antea.myjetbrains.com/youtrack/issue/VL-33)