### PR TITLE
Closes VL-39 Styles div icon and adds link example

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/styles/leaflet-lumo-theme.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/leaflet-lumo-theme.css
@@ -94,13 +94,18 @@
   color: white;
 }
 
-.leaflet-div-icon span{
+.leaflet-div-icon span {
   display: block;
   border-radius: 5px;
-  background-color: rgba(34, 34, 34, 0.4);
+  background-color: var(--lumo-shade-40pct);
+  font-size: var(--lumo-font-size-s);
   color: white;
   width: 80px;
   text-align: center;
+}
+
+.leaflet-div-icon span a {
+  color: var(--lumo-primary-contrast-color);
 }
 
 /* Style for making TileLayers grayscale */

--- a/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/marker/MarkerDivIconExample.java
+++ b/src/test/java/org/vaadin/addons/componentfactory/leaflet/demo/view/marker/MarkerDivIconExample.java
@@ -42,13 +42,11 @@ public class MarkerDivIconExample extends ExampleContainer {
 
 		Marker marker = new Marker(options.getCenter());
 		DivIcon icon = new DivIcon();
-		icon.setHtml("<img src=\"images/marker-icon-demo.png\" /><span>Hello I am a written text</span>");
+		icon.setHtml("<img src=\"images/marker-icon-demo.png\" /><span>Hello I am a written text  <a href=\"#\">a link too</a></span>");
 		marker.setIcon(icon);
 		marker.setDraggable(true);
 		marker.bindPopup("Hey, I'm a DivIcon, drag me if you want");
-		marker.onClick((e) -> {
-			Notification.show("You click the marker.", 3000, Position.TOP_CENTER);
-		});
+		marker.onClick((e) -> Notification.show("You click the marker.", 3000, Position.TOP_CENTER));
 
 		marker.addTo(leafletMap);
 


### PR DESCRIPTION
Updates the styling of the div icon to use Lumo theme variables.

Adds an example of a link within the div icon's HTML content to
demonstrate its functionality.

Screenshot in [VL-39](https://antea.myjetbrains.com/youtrack/issue/VL-39)