### PR TITLE
Closes VL-43 marker captions are left aligned

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/styles/leaflet-lumo-theme.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/leaflet-lumo-theme.css
@@ -94,6 +94,7 @@
   color: white;
 }
 
+/* Style for the text of the markers */
 .leaflet-div-icon span {
   display: block;
   border-radius: 5px;
@@ -101,7 +102,8 @@
   font-size: var(--lumo-font-size-s);
   color: white;
   width: 80px;
-  text-align: center;
+  text-align: left;
+  padding: 0 var(--lumo-space-s) 0 var(--lumo-space-s);
 }
 
 .leaflet-div-icon span a {


### PR DESCRIPTION
Now by default texts of markers are left-aligned.

After the implementation:

<img width="1375" height="993" alt="after" src="https://github.com/user-attachments/assets/a0014319-b050-47a1-8aff-69dc8c504e02" />
