### PR TITLE
closes VL-54 : leaflet-map - on pm:globaleditmodetoggled, pm:globaldragmodetoggled, pm:globalremovalmodetoggled, pm:globaldrawmodetoggled geoman events we fire new vaadin custom events that the server can listen to.

### DIFF
--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/events/ClientGeomanDragToggleEvent.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/events/ClientGeomanDragToggleEvent.java
@@ -1,0 +1,19 @@
+package org.vaadin.addons.componentfactory.leaflet.layer.events;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+import lombok.Getter;
+import org.vaadin.addons.componentfactory.leaflet.LeafletMap;
+
+@Getter
+@DomEvent("pm:globaldragmodetoggled")
+public class ClientGeomanDragToggleEvent extends ComponentEvent<LeafletMap> {
+    private final boolean enabled;
+
+    public ClientGeomanDragToggleEvent(LeafletMap source, boolean fromClient,
+            @EventData("event.detail.enabled") boolean enabled) {
+        super(source, fromClient);
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/events/ClientGeomanDrawToggleEvent.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/events/ClientGeomanDrawToggleEvent.java
@@ -1,0 +1,19 @@
+package org.vaadin.addons.componentfactory.leaflet.layer.events;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+import lombok.Getter;
+import org.vaadin.addons.componentfactory.leaflet.LeafletMap;
+
+@Getter
+@DomEvent("pm:globaldrawmodetoggled")
+public class ClientGeomanDrawToggleEvent extends ComponentEvent<LeafletMap> {
+    private final boolean enabled;
+
+    public ClientGeomanDrawToggleEvent(LeafletMap source, boolean fromClient,
+            @EventData("event.detail.enabled") boolean enabled) {
+        super(source, fromClient);
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/events/ClientGeomanEditToggleEvent.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/events/ClientGeomanEditToggleEvent.java
@@ -1,0 +1,19 @@
+package org.vaadin.addons.componentfactory.leaflet.layer.events;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+import lombok.Getter;
+import org.vaadin.addons.componentfactory.leaflet.LeafletMap;
+
+@Getter
+@DomEvent("pm:globaleditmodetoggled")
+public class ClientGeomanEditToggleEvent extends ComponentEvent<LeafletMap> {
+    private final boolean enabled;
+
+    public ClientGeomanEditToggleEvent(LeafletMap source, boolean fromClient,
+            @EventData("event.detail.enabled") boolean enabled) {
+        super(source, fromClient);
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/events/ClientGeomanRemovalToggleEvent.java
+++ b/src/main/java/org/vaadin/addons/componentfactory/leaflet/layer/events/ClientGeomanRemovalToggleEvent.java
@@ -1,0 +1,19 @@
+package org.vaadin.addons.componentfactory.leaflet.layer.events;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+import lombok.Getter;
+import org.vaadin.addons.componentfactory.leaflet.LeafletMap;
+
+@Getter
+@DomEvent("pm:globalremovalmodetoggled")
+public class ClientGeomanRemovalToggleEvent extends ComponentEvent<LeafletMap> {
+    private final boolean enabled;
+
+    public ClientGeomanRemovalToggleEvent(LeafletMap source, boolean fromClient,
+            @EventData("event.detail.enabled") boolean enabled) {
+        super(source, fromClient);
+        this.enabled = enabled;
+    }
+}

--- a/src/main/resources/META-INF/resources/frontend/leaflet-map.js
+++ b/src/main/resources/META-INF/resources/frontend/leaflet-map.js
@@ -87,6 +87,25 @@ class LeafletMap extends ThemableMixin(PolymerElement) {
     // 1. Set Opt-In immediately
     L.PM.setOptIn(true);
     this.map = this.toLeafletMap(options);
+    const geomanEvents = [
+      "pm:globaleditmodetoggled",
+      "pm:globaldragmodetoggled",
+      "pm:globalremovalmodetoggled",
+      "pm:globaldrawmodetoggled"
+    ];
+
+    geomanEvents.forEach(eventName => {
+      this.map.on(eventName, (e) => {
+        console.info("Geoman Button Toggle Fired Successfully!", eventName, e.enabled);
+        this.dispatchEvent(new CustomEvent(eventName, {
+          detail: {
+            enabled: e.enabled
+          },
+          bubbles: true,   // Let it float up to parent components
+          composed: true  // Let it break through Shadow DOM walls
+        }));
+      });
+    });
   }
 
   /**


### PR DESCRIPTION
the server can listen to the new events i.e.

        ComponentUtil.addListener(getLeafletMap(), ClientGeomanEditToggleEvent.class,
                event -> isGlobalEditEnabled.set(event.isEnabled()));

where isGlobalEditEnabled is an AtomicBoolean in the TmlMap (yt bbox 37049) used to understand if tml should be shown on click or not

    private void onTmlLayerClickedEvent(MouseEvent event, AtomicReference<Registration> tmlDialogClosedRegistration) {
        if (isGlobalEditEnabled.get()) {
            return;
        }